### PR TITLE
Skip parameter parsing for raw post body in HTTP Client

### DIFF
--- a/src/Illuminate/Http/Client/PendingRequest.php
+++ b/src/Illuminate/Http/Client/PendingRequest.php
@@ -895,6 +895,10 @@ class PendingRequest
      */
     protected function parseRequestData($method, $url, array $options)
     {
+        if ($this->bodyFormat === 'body') {
+            return [];
+        }
+
         $laravelData = $options[$this->bodyFormat] ?? $options['query'] ?? [];
 
         $urlString = Str::of($url);

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -152,6 +152,21 @@ class HttpClientTest extends TestCase
         $this->factory->withBody($body, 'application/json')->send('get', 'http://foo.com/api');
     }
 
+    public function testSendRequestBodyWithManyAmpersands()
+    {
+        $body = str_repeat('A thousand &. ', 10000);
+
+        $fakeRequest = function (Request $request) use ($body) {
+            self::assertSame($body, $request->body());
+
+            return ['my' => 'response'];
+        };
+
+        $this->factory->fake($fakeRequest);
+
+        $this->factory->withBody($body, 'text/plain')->send('post', 'http://foo.com/api');
+    }
+
     public function testUrlsCanBeStubbedByPath()
     {
         $this->factory->fake([


### PR DESCRIPTION
Test PR to see result of pipeline
